### PR TITLE
fix: only add op if key exists

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,8 @@ impl<K: Eq + Hash + Send + Clone + Sync, V: Send + Sync> ConcurrentLruCache<K, V
     /// assert_eq!(cache.get(&2), None);
     /// ```
     pub fn get(&self, k: &K) -> Option<&V> {
-        self.add_op(k);
         if let Some(v) = self.map.get(k) {
+            self.add_op(k);
             return Some(v);
         }
         None


### PR DESCRIPTION
We do not want to add every key sent to `get()` to the op queue. This won't change the behavior of how our cache works, since `linkedhashmap` won't act on non existing key-value pairs, but it will lead to better performance since we will stop adding values blindly to the lock free structure, as well as not looking for it later on. 